### PR TITLE
chore(deps): bump typescript from 3.7.5 to 3.9.6 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8419,9 +8419,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "unfetch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^3.0.0",
     "prettier": "^2.0.5",
-    "typescript": "^3.7.5"
+    "typescript": "^3.9.6"
   },
   "dependencies": {
     "@material-ui/core": "^4.9.13",

--- a/frontend/src/components/layout/AdminUsersTable.tsx
+++ b/frontend/src/components/layout/AdminUsersTable.tsx
@@ -39,11 +39,7 @@ export type handleClickMenuParam =
 
 export type handleClickMenuType = (param: handleClickMenuParam) => void;
 
-export type Data = UserTableData extends Record<string, string | number> & {
-  id: number;
-}
-  ? UserTableData
-  : never;
+export type Data = UserTableData;
 
 function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
   if (b[orderBy] < a[orderBy]) {


### PR DESCRIPTION
dependabotのPRに変更加えるとrebaseとforce-pushで破壊されるので