### PR TITLE
リロード時にCookieが送信されない問題の修正

### DIFF
--- a/backend/interfaces/api/public/session.go
+++ b/backend/interfaces/api/public/session.go
@@ -51,7 +51,7 @@ func newCookie(key, value string, age time.Duration) *http.Cookie {
 	if !insecureCookie() {
 		cookie.HttpOnly = true
 		cookie.Secure = true
-		cookie.SameSite = http.SameSiteStrictMode
+		cookie.SameSite = http.SameSiteLaxMode
 	}
 
 	cookie.Name = key


### PR DESCRIPTION
Firefoxなどの一部環境ではSameSite=Strictだと死ぬらしい?
とりあえずLaxで問題ないので無効化