### PR TITLE
feat: add external API to dump all member roles

### DIFF
--- a/backend/cmd/init.go
+++ b/backend/cmd/init.go
@@ -271,6 +271,8 @@ func initHandler(cfg *config.Config, addr string, digc *dig.Container) *echo.Ech
 
 		g.GET("/find_role", eh.GetUserRoleFromSlackID)
 
+		g.GET("/all_member_roles", eh.GetAllMemberRolesBySlackID)
+
 		return nil
 	}))
 

--- a/backend/interfaces/api/external/external.go
+++ b/backend/interfaces/api/external/external.go
@@ -43,3 +43,25 @@ func (h *ExternalHandler) GetUserRoleFromSlackID(e echo.Context) error {
 		"role": role,
 	})
 }
+
+func (h *ExternalHandler) GetAllMemberRolesBySlackID(e echo.Context) error {
+	roles, err := h.eu.GetAllMemberRolesBySlackID(e.Request().Context())
+
+	if err != nil {
+		return xerrors.Errorf("failed to retrieve users' roles: %w", err);
+	}
+	
+	type ResponceItem struct {
+		Role string `json:"role"`
+	}
+
+	responce := map[string]ResponceItem{}
+
+	for id, role := range roles {
+		responce[id] = ResponceItem{
+			Role: role,
+		}
+	}
+
+	return e.JSON(http.StatusOK, responce)
+}

--- a/backend/usecase/externalIntegration.go
+++ b/backend/usecase/externalIntegration.go
@@ -1,25 +1,30 @@
 package usecase
 
 import (
+	"context"
+
 	"github.com/MISW/Portal/backend/domain"
 	"github.com/MISW/Portal/backend/domain/repository"
 	"github.com/MISW/Portal/backend/internal/rest"
 	"golang.org/x/xerrors"
 )
 
-func NewExternalIntegrationUsecase(repo repository.ExternalIntegrationRepository) ExternalIntegrationUsecase {
+func NewExternalIntegrationUsecase(repo repository.ExternalIntegrationRepository, userRepo repository.UserRepository) ExternalIntegrationUsecase {
 	return &externalIntegrationUsecase{
 		repo: repo,
+		userRepo: userRepo,
 	}
 }
 
 // ExternalIntegrationUsecase - 外部連携サービスのための
 type ExternalIntegrationUsecase interface {
 	GetUserRoleFromSlackID(slackID string) (string, error)
+	GetAllMemberRolesBySlackID(ctx context.Context) (map[string] string, error)
 }
 
 type externalIntegrationUsecase struct {
 	repo repository.ExternalIntegrationRepository
+	userRepo repository.UserRepository
 }
 
 var _ ExternalIntegrationUsecase = &externalIntegrationUsecase{}
@@ -36,4 +41,22 @@ func (u *externalIntegrationUsecase) GetUserRoleFromSlackID(slackID string) (str
 	}
 
 	return role, nil
+}
+
+func (u *externalIntegrationUsecase) GetAllMemberRolesBySlackID(ctx context.Context) (map[string] string, error) {
+	users, err := u.userRepo.List(ctx)
+
+	if err != nil {
+		return nil, xerrors.Errorf("failed to get user roles: %w", err)
+	}
+
+	roles := map[string]string{}
+	for _, user := range users {
+		if user.SlackID == "" {
+			continue
+		}
+		roles[user.SlackID] = string(user.Role)
+	}
+
+	return roles, nil
 }


### PR DESCRIPTION
内部向け: https://github.com/MISW/sysad/issues/7

Portalに登録されている全員のSlackIDと権限を得られるエンドポイントを追加した