### PR TITLE
fix: fix issues for building frontend images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
     env_file: ./dev.env
     volumes:
       - ./frontend:/frontend
-      - node_modules:/frontend/node_modules
       - ./scripts/docker-entrypoint.frontend.sh:/bin/docker-entrypoint.frontend.sh
     expose:
       - "3000"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,2 +1,2 @@
-node_modules
-.next
+/node_modules
+/.next


### PR DESCRIPTION
初回起動時に`pnpm`が見つからないと言われるエラーを修正(したつもり)

なぜかわからんがfs周りで怪しげなエラーが起きていたので手を入れてみた。直ってるのかはわからない